### PR TITLE
feat: support having a space in the path for the vault.

### DIFF
--- a/src/copilot/CopilotAgent.ts
+++ b/src/copilot/CopilotAgent.ts
@@ -37,7 +37,7 @@ class CopilotAgent implements SettingsObserver {
 
 	public startAgent(): void {
 		try {
-			this.agent = spawn(this.nodePath, [this.agentPath, "--stdio"], {
+			this.agent = spawn(this.nodePath, [`"${this.agentPath}"`, "--stdio"], {
 				shell: true,
 				stdio: "pipe",
 			});


### PR DESCRIPTION
I got an issue with plugin due to my plugin host in Icloud Drive which is have space in the path, agentPath have space and couldn't run with node cli

fix #4 