### PR TITLE
feat: redesign chat UI

### DIFF
--- a/src/copilot-chat/components/Chat.tsx
+++ b/src/copilot-chat/components/Chat.tsx
@@ -18,6 +18,8 @@ const Chat: React.FC = () => {
 		conversations,
 		activeConversationId,
 		initConversationService,
+		deleteMessage,
+		retryMessage,
 	} = useCopilotStore();
 
 	useEffect(() => {
@@ -28,11 +30,12 @@ const Chat: React.FC = () => {
 
 	const displayMessages = activeConversationId
 		? conversations.find((conv) => conv.id === activeConversationId)
-				?.messages || []
+			?.messages || []
 		: messages;
 
 	const formattedMessages: MessageProps[] = displayMessages.map(
 		(message) => ({
+			messageId: message.id,
 			icon: message.role === "assistant" ? copilotIcon : userIcon,
 			name: message.role === "assistant" ? "GitHub Copilot" : "User",
 			message: message.content,
@@ -40,13 +43,53 @@ const Chat: React.FC = () => {
 		}),
 	);
 
+	// Handlers for message actions
+	const handleCopy: (id?: string | number, content?: string) => void = (
+		id,
+		content,
+	) => {
+		/* No changes needed here */
+	};
+
+	const handleDelete: (id?: string | number) => void = (id) => {
+		if (typeof id === "string") {
+			deleteMessage(plugin, id);
+		} else if (typeof id === "number") {
+			const conv = activeConversationId
+				? conversations.find((c) => c.id === activeConversationId)
+				: undefined;
+			const list = conv ? conv.messages : messages;
+			const msg = list[id ?? -1];
+			if (msg) deleteMessage(plugin, msg.id);
+		}
+	};
+
+	const handleRetry: (id?: string | number) => void = (id) => {
+		if (typeof id === "string") {
+			retryMessage(plugin, id);
+		} else if (typeof id === "number") {
+			const conv = activeConversationId
+				? conversations.find((c) => c.id === activeConversationId)
+				: undefined;
+			const list = conv ? conv.messages : messages;
+			const msg = list[id ?? -1];
+			if (msg) retryMessage(plugin, msg.id);
+		}
+	};
+
 	return (
 		<MainLayout>
 			<Header />
 			{formattedMessages.length === 0 ? (
 				<NoHistory />
 			) : (
-				<MessageList messages={formattedMessages} />
+				<MessageList
+					messages={formattedMessages}
+					isLoading={isLoading}
+					onCopy={handleCopy}
+					onDelete={handleDelete}
+					onRetry={handleRetry}
+				/>
 			)}
 			<Input isLoading={isLoading} />
 		</MainLayout>

--- a/src/copilot-chat/components/atoms/FileSuggestion.tsx
+++ b/src/copilot-chat/components/atoms/FileSuggestion.tsx
@@ -7,7 +7,7 @@ const BASE_CLASSNAME = "copilot-chat-file-suggestion";
 
 interface FileSuggestionProps {
 	query: string;
-	position: { top: number; left: number };
+	position?: { top: number; left: number };
 	onSelect: (file: { path: string; filename: string }) => void;
 	onClose: () => void;
 	plugin: CopilotPlugin | undefined;
@@ -48,7 +48,7 @@ const FileSuggestion: React.FC<FileSuggestionProps> = ({
 			setSelectedIndex(
 				(prev) => (prev - 1 + files.length) % files.length,
 			);
-		} else if (e.key === "Enter") {
+		} else if (e.key === "Enter" || e.key === "Tab") {
 			e.preventDefault();
 			if (files[selectedIndex]) {
 				handleSelect(files[selectedIndex]);
@@ -86,29 +86,17 @@ const FileSuggestion: React.FC<FileSuggestionProps> = ({
 	};
 
 	const getDirectory = (path: string) => {
-		const lastSlashIndex = path.lastIndexOf("/");
-		if (lastSlashIndex === -1) return "";
-		return path.substring(0, lastSlashIndex);
+		// Normalize path by trimming leading/trailing slashes
+		const normalized = (path || "").replace(/^\/+|\/+$/g, "");
+		const parts = normalized.split("/").filter(Boolean);
+		// If no folder part, it's root
+		if (parts.length <= 1) return "";
+		// Join folder parts and ensure a leading slash
+		return "/" + parts.slice(0, -1).join("/");
 	};
 
 	return (
-		<div
-			className={concat(BASE_CLASSNAME, "container")}
-			style={{
-				position: "absolute",
-				top: `-200px`,
-				left: `10px`,
-				width: "calc(100% - 20px)",
-				maxHeight: "200px",
-				overflowY: "auto",
-				zIndex: 1000,
-				backgroundColor: "var(--background-primary)",
-				border: "1px solid var(--background-modifier-border)",
-				borderRadius: "4px",
-				boxShadow: "0px 5px 10px rgba(0, 0, 0, 0.1)",
-			}}
-			ref={containerRef}
-		>
+		<div className={concat(BASE_CLASSNAME, "container")} ref={containerRef}>
 			{files.length === 0 ? (
 				<div
 					className={concat(BASE_CLASSNAME, "no-results")}
@@ -117,47 +105,25 @@ const FileSuggestion: React.FC<FileSuggestionProps> = ({
 					No files found
 				</div>
 			) : (
-				<div className={concat(BASE_CLASSNAME, "list")}>
-					{files.map((file, index) => (
-						<div
-							key={file.path}
-							className={cx(
-								concat(BASE_CLASSNAME, "item"),
-								index === selectedIndex
-									? concat(BASE_CLASSNAME, "item-selected")
-									: "",
-							)}
-							onClick={() => handleSelect(file)}
-							style={{
-								padding: "8px 10px",
-								cursor: "pointer",
-								borderBottom:
-									"1px solid var(--background-modifier-border)",
-								backgroundColor:
-									index === selectedIndex
-										? "var(--background-secondary)"
-										: "transparent",
-								display: "flex",
-								flexDirection: "column",
-							}}
-						>
-							<div style={{ fontWeight: "500" }}>
-								{file.basename}
-							</div>
-							{getDirectory(file.path) && (
-								<div
-									style={{
-										fontSize: "0.8em",
-										color: "var(--text-muted)",
-										marginTop: "2px",
-									}}
-								>
-									{getDirectory(file.path)}
-								</div>
-							)}
+				files.map((file, index) => (
+					<div
+						key={file.path}
+						className={cx(
+							concat(BASE_CLASSNAME, "item"),
+							index === selectedIndex
+								? concat(BASE_CLASSNAME, "item-selected")
+								: "",
+						)}
+						onClick={() => handleSelect(file)}
+					>
+						<div className={concat(BASE_CLASSNAME, "item-name")}>
+							{file.basename}
 						</div>
-					))}
-				</div>
+						<div className={concat(BASE_CLASSNAME, "item-path")}>
+							{getDirectory(file.path)}
+						</div>
+					</div>
+				))
 			)}
 		</div>
 	);

--- a/src/copilot-chat/components/atoms/LinkedNotes.tsx
+++ b/src/copilot-chat/components/atoms/LinkedNotes.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { cx } from "../../../utils/style";
+import { usePlugin } from "../../hooks/usePlugin";
+import { TFile, Notice } from "obsidian";
+
+const BASE_CLASSNAME = "copilot-chat-message";
+
+export interface LinkedNoteItem {
+	path: string;
+	filename: string;
+	content: string;
+}
+
+interface LinkedNotesProps {
+	notes?: LinkedNoteItem[];
+}
+
+const LinkedNotes: React.FC<LinkedNotesProps> = ({ notes }) => {
+	const plugin = usePlugin();
+
+	if (!notes || notes.length === 0) return null;
+
+	const openLinkedNote = (note: { path: string; filename: string }) => {
+		if (!plugin) return;
+		try {
+			const file = plugin.app.vault.getAbstractFileByPath(note.path);
+			if (file instanceof TFile) {
+				// If already open in any leaf, activate that leaf
+				const leaves = plugin.app.workspace.getLeavesOfType("markdown");
+				const existing = leaves.find((leaf) => {
+					type ViewWithFile = { file?: { path?: string } };
+					const view = leaf.view as unknown as ViewWithFile;
+					return view?.file?.path === file.path;
+				});
+				if (existing) {
+					plugin.app.workspace.revealLeaf(existing);
+					return;
+				}
+
+				// Otherwise open in a new leaf
+				plugin.app.workspace
+					.getLeaf(true)
+					.openFile(file)
+					.catch((e) => {
+						console.error("Failed to open file", e);
+						new Notice("Unable to open file: " + note.filename);
+					});
+			} else {
+				plugin.app.workspace.openLinkText(note.filename, "", false);
+			}
+		} catch (e) {
+			console.error("Open note error", e);
+			new Notice("Failed to open note: " + note.filename);
+		}
+	};
+
+	return (
+		<div className={`${BASE_CLASSNAME}-linked-notes-list`}>
+			{notes.map((note, index) => (
+				<div
+					key={index}
+					className={cx(`${BASE_CLASSNAME}-linked-note`, "tag")}
+					role="button"
+					tabIndex={0}
+					onClick={() => openLinkedNote(note)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" || e.key === " ") {
+							e.preventDefault();
+							openLinkedNote(note);
+						}
+					}}
+					aria-label={`Open note ${note.filename}`}
+				>
+					{note.filename}
+				</div>
+			))}
+		</div>
+	);
+};
+
+export { LinkedNotes };

--- a/src/copilot-chat/components/atoms/Message.tsx
+++ b/src/copilot-chat/components/atoms/Message.tsx
@@ -5,6 +5,8 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { usePlugin } from "../../hooks/usePlugin";
+import { LinkedNotes } from "./LinkedNotes";
+import { ObsidianIcon } from "./ObsidianIcon";
 
 const BASE_CLASSNAME = "copilot-chat-message";
 
@@ -13,6 +15,10 @@ export interface MessageProps {
 	icon: string;
 	name: string;
 	message: string;
+	messageId?: string | number;
+	onCopy?: (messageId?: string | number, content?: string) => void;
+	onDelete?: (messageId?: string | number) => void;
+	onRetry?: (messageId?: string | number) => void;
 	linkedNotes?: {
 		path: string;
 		filename: string;
@@ -27,10 +33,91 @@ interface CodeProps {
 	children?: React.ReactNode;
 }
 
-const ChatMessage: React.FC<MessageProps> = (props) => {
-	const { className, icon, name, message, linkedNotes } = props;
+// Build component mappings for ReactMarkdown
+const getMarkdownComponents = (isDarkTheme: boolean) => {
+	const themeClass = `theme-${isDarkTheme ? "dark" : "light"}`;
+	const codeStyle = isDarkTheme
+		? vscDarkPlus
+		: (oneLight as Record<string, React.CSSProperties>);
+
+	const CodeBlock = ({
+		className,
+		inline,
+		children,
+		...props
+	}: CodeProps) => {
+		const match = className?.match(/language-(\w+)/);
+
+		if (!inline && match) {
+			return (
+				<SyntaxHighlighter
+					language={match[1]}
+					style={codeStyle}
+					PreTag="div"
+					className={themeClass}
+					customStyle={{
+						background: "var(--code-background)",
+						borderRadius: "4px",
+					}}
+					{...props}
+				>
+					{String(children || "").replace(/\n$/, "")}
+				</SyntaxHighlighter>
+			);
+		}
+
+		return (
+			<code className={className} {...props}>
+				{children}
+			</code>
+		);
+	};
+
+	return {
+		p: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
+		code: CodeBlock,
+	};
+};
+
+// Shared inner render: text, code highlighting, and linked notes
+const ChatMessageContent: React.FC<{
+	message: string;
+	isDarkTheme: boolean;
+	showRaw: boolean;
+	onClick?: React.MouseEventHandler<HTMLDivElement>;
+	style?: React.CSSProperties;
+}> = ({ message, isDarkTheme, onClick, style, showRaw }) => {
+	return (
+		<div
+			className={concat(BASE_CLASSNAME, "message")}
+			onClick={onClick}
+			style={style}
+		>
+			{showRaw ? (
+				<p>{message}</p>
+			) : (
+				<ReactMarkdown components={getMarkdownComponents(isDarkTheme)}>
+					{message}
+				</ReactMarkdown>
+			)}
+		</div>
+	);
+};
+
+// Visual wrapper: Copilot messages
+export const CopilotMessage: React.FC<MessageProps> = (props) => {
+	const {
+		className,
+		message,
+		linkedNotes,
+		messageId,
+		onCopy,
+		onDelete,
+		onRetry,
+	} = props;
 	const plugin = usePlugin();
 	const [isCopied, setIsCopied] = React.useState(false);
+	const [showRaw, setShowRaw] = React.useState(false);
 
 	const isDarkTheme = useMemo(() => {
 		return document.body.classList.contains("theme-dark");
@@ -41,161 +128,219 @@ const ChatMessage: React.FC<MessageProps> = (props) => {
 			.writeText(message)
 			.then(() => {
 				setIsCopied(true);
-				setTimeout(() => {
-					setIsCopied(false);
-				}, 2000);
+				setTimeout(() => setIsCopied(false), 2000);
 			})
-			.catch((err) => {
-				console.error("Failed to copy message: ", err);
-			});
+			.catch((err) => console.error("Failed to copy message: ", err));
+		onCopy?.(messageId, message);
+	};
+
+	const handleDelete = () => {
+		onDelete?.(messageId);
+	};
+
+	const handleRetry = () => {
+		onRetry?.(messageId);
 	};
 
 	return (
 		<div
-			className={cx(concat(BASE_CLASSNAME, "container"), className || "")}
+			className={cx(
+				concat(BASE_CLASSNAME, "container"),
+				concat(BASE_CLASSNAME, "assistant"),
+				className || "",
+			)}
 		>
-			<div className={concat(BASE_CLASSNAME, "info")}>
-				<div
-					className={concat(BASE_CLASSNAME, "icon")}
-					dangerouslySetInnerHTML={{ __html: icon }}
-				/>
-				<div className={concat(BASE_CLASSNAME, "name")}>{name}</div>
+			<ChatMessageContent
+				message={message}
+				isDarkTheme={isDarkTheme}
+				showRaw={showRaw}
+			/>
+			{linkedNotes && linkedNotes.length > 0 && (
+				<LinkedNotes notes={linkedNotes} />
+			)}
+			<div className={concat(BASE_CLASSNAME, "actions")}>
+				{/* actions moved to bottom */}
 				<button
 					className={concat(BASE_CLASSNAME, "copy-button")}
 					onClick={handleCopyMessage}
-					title={isCopied ? "Copied!" : "Copy message"}
 					aria-label={isCopied ? "Copied!" : "Copy message"}
 				>
-					{isCopied ? (
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<polyline points="20 6 9 17 4 12"></polyline>
-						</svg>
-					) : (
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<rect
-								x="9"
-								y="9"
-								width="13"
-								height="13"
-								rx="2"
-								ry="2"
-							></rect>
-							<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-						</svg>
-					)}
+					<ObsidianIcon
+						name={isCopied ? "lucide-check" : "lucide-copy"}
+					/>
 				</button>
-			</div>
-			<div className={concat(BASE_CLASSNAME, "message")}>
-				<ReactMarkdown
-					components={{
-						p({ children }) {
-							return (
-								<p style={{ whiteSpace: "pre-wrap" }}>
-									{children}
-								</p>
-							);
-						},
-						code({
-							className,
-							inline,
-							children,
-							...props
-						}: CodeProps) {
-							const match = /language-(\w+)/.exec(
-								className || "",
-							);
-							return !inline && match ? (
-								<SyntaxHighlighter
-									language={match[1]}
-									style={
-										isDarkTheme
-											? vscDarkPlus
-											: (oneLight as Record<
-													string,
-													React.CSSProperties
-												>)
-									}
-									PreTag="div"
-									className={`theme-${isDarkTheme ? "dark" : "light"}`}
-									customStyle={{
-										background: "var(--code-background)",
-										borderRadius: "4px",
-									}}
-									{...props}
-								>
-									{String(children || "").replace(/\n$/, "")}
-								</SyntaxHighlighter>
-							) : (
-								<code className={className} {...props}>
-									{children}
-								</code>
-							);
-						},
-					}}
+				<button
+					className={concat(BASE_CLASSNAME, "switch-button")}
+					onClick={() => setShowRaw((v) => !v)}
+					aria-label={
+						showRaw ? "Switch to rendered" : "Switch to source"
+					}
 				>
-					{message}
-				</ReactMarkdown>
-
-				{linkedNotes && linkedNotes.length > 0 && (
-					<div className={concat(BASE_CLASSNAME, "linked-notes")}>
-						<div
-							className={concat(
-								BASE_CLASSNAME,
-								"linked-notes-title",
-							)}
-						>
-							Linked Notes:
-						</div>
-						<div
-							className={concat(
-								BASE_CLASSNAME,
-								"linked-notes-list",
-							)}
-						>
-							{linkedNotes.map((note, index) => (
-								<div
-									key={index}
-									className={concat(
-										BASE_CLASSNAME,
-										"linked-note",
-									)}
-								>
-									<span
-										className={concat(
-											BASE_CLASSNAME,
-											"linked-note-filename",
-										)}
-									>
-										[[{note.filename}]]
-									</span>
-								</div>
-							))}
-						</div>
-					</div>
-				)}
+					<ObsidianIcon
+						name={showRaw ? "lucide-book-open" : "lucide-code-xml"}
+					/>
+				</button>
+				<button
+					className={concat(BASE_CLASSNAME, "delete-button")}
+					onClick={handleDelete}
+					aria-label="Delete message"
+				>
+					<ObsidianIcon name="lucide-trash-2" />
+				</button>
+				<button
+					className={concat(BASE_CLASSNAME, "retry-button")}
+					onClick={handleRetry}
+					aria-label="Retry"
+				>
+					<ObsidianIcon name="lucide-rotate-cw" />
+				</button>
 			</div>
 		</div>
 	);
 };
 
-export default ChatMessage;
+// Visual wrapper: User messages
+export const UserMessage: React.FC<MessageProps> = (props) => {
+	const { className, message, linkedNotes, messageId, onCopy, onDelete } =
+		props;
+	const plugin = usePlugin();
+	const [isCopied, setIsCopied] = React.useState(false);
+	const [showRaw, setShowRaw] = React.useState(false);
+	const [isCollapsed, setIsCollapsed] = React.useState<boolean>(true);
+	const [contentHeight, setContentHeight] = React.useState<number>(0);
+
+	const collapsibleRef = React.useRef<HTMLDivElement>(null);
+	const [animatedHeight, setAnimatedHeight] = React.useState<number>(0);
+
+	React.useLayoutEffect(() => {
+		const wrapper = collapsibleRef.current;
+		if (!wrapper) return;
+		const content = wrapper.querySelector(
+			`.${BASE_CLASSNAME}-message`,
+		) as HTMLElement | null;
+		if (!content) return;
+
+		// Expanded height equals real content height; collapsed is min(full, 100px)
+		let full = content.scrollHeight;
+		if (showRaw) {
+			// In source mode, use the sum of all child element heights (including margins)
+			const children = Array.from(content.children) as HTMLElement[];
+			full = children.reduce((sum, el) => {
+				const rectH = el.offsetHeight;
+				const cs = window.getComputedStyle(el);
+				const mt = parseFloat(cs.marginTop || "0");
+				const mb = parseFloat(cs.marginBottom || "0");
+				return sum + rectH + mt + mb;
+			}, 0);
+		}
+		setContentHeight(full);
+		const collapsed = Math.min(full, 100);
+		const target = isCollapsed ? collapsed : full;
+		setAnimatedHeight(target);
+
+		// If content height is not greater than 100px, do not collapse
+		if (full <= 100 && isCollapsed) {
+			setIsCollapsed(false);
+		}
+	}, [isCollapsed, message, showRaw]);
+
+	// When collapsed, if horizontal scroll exists, scroll back to the left
+	React.useEffect(() => {
+		const wrapper = collapsibleRef.current;
+		if (!wrapper) return;
+		const content = wrapper.querySelector(
+			`.${BASE_CLASSNAME}-message`,
+		) as HTMLElement | null;
+		if (!content) return;
+		if (isCollapsed && content.scrollLeft > 0) {
+			content.scrollTo({ left: 0, behavior: "smooth" });
+		}
+	}, [isCollapsed]);
+
+	const isDarkTheme = useMemo(() => {
+		return document.body.classList.contains("theme-dark");
+	}, [plugin?.app]);
+
+	const handleCopyMessage = () => {
+		onCopy?.(messageId, message);
+	};
+
+	const handleDelete = () => {
+		onDelete?.(messageId);
+	};
+
+	return (
+		<div
+			ref={collapsibleRef}
+			className={cx(
+				concat(BASE_CLASSNAME, "container"),
+				concat(BASE_CLASSNAME, "user"),
+				contentHeight > 100
+					? concat(BASE_CLASSNAME, "collapsible")
+					: "",
+				isCollapsed ? concat(BASE_CLASSNAME, "collapsed") : "",
+				className || "",
+			)}
+		>
+			<ChatMessageContent
+				message={message}
+				isDarkTheme={isDarkTheme}
+				showRaw={showRaw}
+				onClick={isCollapsed ? () => setIsCollapsed(false) : undefined}
+				style={
+					contentHeight > 100 ? { height: animatedHeight } : undefined
+				}
+			/>
+			{contentHeight > 100 && (
+				<button
+					className={cx(
+						concat(BASE_CLASSNAME, "toggle-button"),
+						concat(BASE_CLASSNAME, "expand-collapse-button"),
+						isCollapsed ? concat(BASE_CLASSNAME, "collapsed") : "",
+					)}
+					onClick={() => setIsCollapsed((c) => !c)}
+					aria-label={
+						isCollapsed ? "Expand message" : "Collapse message"
+					}
+				>
+					<ObsidianIcon name="lucide-chevron-down" />
+				</button>
+			)}
+
+			{linkedNotes && linkedNotes.length > 0 && (
+				<LinkedNotes notes={linkedNotes} />
+			)}
+
+			<div className={concat(BASE_CLASSNAME, "actions")}>
+				{/* actions moved below for user */}
+				<button
+					className={concat(BASE_CLASSNAME, "copy-button")}
+					onClick={handleCopyMessage}
+					aria-label={isCopied ? "Copied!" : "Copy message"}
+				>
+					<ObsidianIcon
+						name={isCopied ? "lucide-check" : "lucide-copy"}
+					/>
+				</button>
+				<button
+					className={concat(BASE_CLASSNAME, "switch-button")}
+					onClick={() => setShowRaw((v) => !v)}
+					aria-label={
+						showRaw ? "Switch to rendered" : "Switch to source"
+					}
+				>
+					<ObsidianIcon
+						name={showRaw ? "lucide-book-open" : "lucide-code-xml"}
+					/>
+				</button>
+				<button
+					className={concat(BASE_CLASSNAME, "delete-button")}
+					onClick={handleDelete}
+					aria-label="Delete message"
+				>
+					<ObsidianIcon name="lucide-trash-2" />
+				</button>
+			</div>
+		</div>
+	);
+};

--- a/src/copilot-chat/components/atoms/ObsidianIcon.tsx
+++ b/src/copilot-chat/components/atoms/ObsidianIcon.tsx
@@ -1,0 +1,24 @@
+import { setIcon } from "obsidian";
+import React from "react";
+
+export const ObsidianIcon: React.FC<{
+	name: string;
+	className?: string;
+	style?: React.CSSProperties;
+}> = ({ name, className, style }) => {
+	const ref = React.useRef<HTMLSpanElement>(null);
+
+	React.useEffect(() => {
+		if (ref.current) {
+			setIcon(ref.current, name);
+		}
+	}, [name]);
+
+	return (
+		<span
+			ref={ref}
+			className={className}
+			style={{ display: "flex", ...style }}
+		/>
+	);
+};

--- a/src/copilot-chat/components/sections/Header.tsx
+++ b/src/copilot-chat/components/sections/Header.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { concat } from "../../../utils/style";
+import { concat, cx } from "../../../utils/style";
 import { usePlugin } from "../../hooks/usePlugin";
 import { useCopilotStore } from "../../store/store";
 import ConversationSelector from "./ConversationSelector";
+import { ObsidianIcon } from "../atoms/ObsidianIcon";
 
 const BASE_CLASSNAME = "copilot-chat-header";
 
@@ -46,65 +47,34 @@ const Header: React.FC = () => {
 			<div className={concat(BASE_CLASSNAME, "title")}>Chat</div>
 			<div className={concat(BASE_CLASSNAME, "actions")}>
 				<button
-					className={concat(BASE_CLASSNAME, "action-button")}
+					className={cx(
+						concat(BASE_CLASSNAME, "action-button"),
+						"clickable-icon",
+					)}
 					onClick={handleNewConversation}
-					title="Start new conversation"
+					aria-label="Start new conversation"
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<path d="M12 5v14"></path>
-						<path d="M5 12h14"></path>
-					</svg>
+					<ObsidianIcon name="lucide-plus" />
 				</button>
 				<button
-					className={concat(BASE_CLASSNAME, "action-button")}
+					className={cx(
+						concat(BASE_CLASSNAME, "action-button"),
+						"clickable-icon",
+					)}
 					onClick={toggleConversationSelector}
-					title="View conversation history"
+					aria-label="View conversation history"
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<circle cx="12" cy="12" r="10"></circle>
-						<polyline points="12 6 12 12 16 14"></polyline>
-					</svg>
+					<ObsidianIcon name="lucide-history" />
 				</button>
 				<button
-					className={concat(BASE_CLASSNAME, "action-button")}
+					className={cx(
+						concat(BASE_CLASSNAME, "action-button"),
+						"clickable-icon",
+					)}
 					onClick={handleClearChat}
-					title="Delete this conversation"
+					aria-label="Delete this conversation"
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<path d="M3 6h18"></path>
-						<path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
-						<path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
-					</svg>
+					<ObsidianIcon name="lucide-trash" />
 				</button>
 			</div>
 			<ConversationSelector

--- a/src/copilot-chat/components/sections/Input.tsx
+++ b/src/copilot-chat/components/sections/Input.tsx
@@ -138,7 +138,7 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 	const handleAttachClick = () => {
 		setFileSearchQuery("");
 		setShowFileSuggestion(true);
-		// 将下拉定位到文本框光标（简单保持现状）
+		// Position dropdown at textarea cursor (simple, keep current behavior)
 		updateCursorPosition();
 	};
 
@@ -172,14 +172,14 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 					.openFile(file)
 					.catch((e) => {
 						console.error("Failed to open file", e);
-						new Notice("无法打开文件: " + note.filename);
+						new Notice("Cannot open file: " + note.filename);
 					});
 			} else {
 				plugin.app.workspace.openLinkText(note.filename, "", false);
 			}
 		} catch (e) {
 			console.error("Open note error", e);
-			new Notice("打开笔记失败: " + note.filename);
+			new Notice("Failed to open note: " + note.filename);
 		}
 	};
 
@@ -189,7 +189,7 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 		if (!el) return;
 		const style = window.getComputedStyle(el);
 		const lineHeight = parseFloat(style.lineHeight || "20");
-		const maxHeight = lineHeight * 10; // 10 行上限
+		const maxHeight = lineHeight * 10; // Max 10 lines
 		el.style.height = "auto";
 		const next = Math.min(el.scrollHeight, maxHeight);
 		el.style.height = `${next}px`;
@@ -300,7 +300,7 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 
 	return (
 		<div className={concat(BASE_CLASSNAME, "container")}>
-			{/* 第一部分：附件栏 */}
+			{/* Section 1: Attachments bar */}
 			<div className={concat(BASE_CLASSNAME, "attachments-bar")}>
 				<button
 					className={concat(BASE_CLASSNAME, "attach-button")}
@@ -345,7 +345,7 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 				))}
 			</div>
 
-			{/* 第二部分：可自增高度输入框 */}
+			{/* Section 2: Auto-sizing input box */}
 			<div
 				className={concat(BASE_CLASSNAME, "input-area")}
 				style={{ position: "relative" }}
@@ -376,7 +376,7 @@ const Input: React.FC<InputProps> = ({ isLoading = false }) => {
 				)}
 			</div>
 
-			{/* 第三部分：模型选择器与发送按钮 */}
+			{/* Section 3: Model selector and send button */}
 			<div className={concat(BASE_CLASSNAME, "actions-bar")}>
 				<ModelSelector isAuthenticated={isAuthenticated} />
 				<button

--- a/src/copilot-chat/components/sections/MessageList.tsx
+++ b/src/copilot-chat/components/sections/MessageList.tsx
@@ -1,38 +1,87 @@
-import React, { useEffect, useRef } from "react";
-import ChatMessage, { MessageProps } from "../atoms/Message";
-import { concat, cx } from "../../../utils/style";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
+import { CopilotMessage, UserMessage, MessageProps } from "../atoms/Message";
+import { concat } from "../../../utils/style";
 
 const BASE_CLASSNAME = "copilot-chat-message-list";
 
 interface MessageListProps {
 	messages: MessageProps[];
+	isLoading?: boolean;
+	onCopy?: (id?: string | number, content?: string) => void;
+	onDelete?: (id?: string | number) => void;
+	onRetry?: (id?: string | number) => void;
 }
 
-const MessageList: React.FC<MessageListProps> = ({ messages }) => {
+const MessageList: React.FC<MessageListProps> = ({
+	messages,
+	isLoading,
+	onCopy,
+	onDelete,
+	onRetry,
+}) => {
 	const endOfMessagesRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
-	useEffect(() => {
-		if (endOfMessagesRef.current) {
-			endOfMessagesRef.current.scrollIntoView({ behavior: "smooth" });
+	const scrollToBottom = (behavior: ScrollBehavior = "smooth") => {
+		const container = containerRef.current;
+		if (container) {
+			container.scrollTo({ top: container.scrollHeight, behavior });
 		}
+		const endMarker = endOfMessagesRef.current;
+		if (endMarker) {
+			endMarker.scrollIntoView({ behavior });
+		}
+	};
+
+	useLayoutEffect(() => {
+		// 在消息变更后，等待布局完成再滚动，保证切换历史记录时可靠
+		const timer = setTimeout(() => {
+			scrollToBottom("smooth");
+		}, 0);
+		return () => clearTimeout(timer);
 	}, [messages]);
 
+	// 初次挂载后，延迟滚动一次，避免 Obsidian 启动阶段渲染时机导致未滚动
+	useLayoutEffect(() => {
+		const timer = setTimeout(() => {
+			scrollToBottom("auto");
+		}, 30);
+		return () => clearTimeout(timer);
+	}, []);
+
+	useEffect(() => {
+		if (isLoading) {
+			scrollToBottom("smooth");
+		}
+	}, [isLoading]);
+
+	// 当历史记录加载完成（isLoading -> false）时，滚动到底部
+	useEffect(() => {
+		if (!isLoading) {
+			scrollToBottom("smooth");
+		}
+	}, [isLoading, messages]);
+
 	return (
-		<div className={concat(BASE_CLASSNAME, "container")}>
-			{messages.map((message, index) => (
-				<ChatMessage
-					key={index}
-					className={cx(
-						concat(BASE_CLASSNAME, "item"),
-						message.name === "GitHub Copilot"
-							? concat(BASE_CLASSNAME, "assistant")
-							: concat(BASE_CLASSNAME, "user"),
-					)}
-					icon={message.icon}
-					name={message.name}
-					message={message.message}
-				/>
-			))}
+		<div className={concat(BASE_CLASSNAME, "container")} ref={containerRef}>
+			{messages.map((message, index) => {
+				const isCopilot = message.name === "GitHub Copilot";
+				const Comp = isCopilot ? CopilotMessage : UserMessage;
+				return (
+					<Comp
+						key={message.messageId ?? index}
+						className={concat(BASE_CLASSNAME, "item")}
+						icon={message.icon}
+						name={message.name}
+						message={message.message}
+						linkedNotes={message.linkedNotes}
+						messageId={message.messageId ?? index}
+						onCopy={onCopy}
+						onDelete={onDelete}
+						onRetry={onRetry}
+					/>
+				);
+			})}
 			<div ref={endOfMessagesRef} />
 		</div>
 	);

--- a/src/copilot-chat/components/sections/MessageList.tsx
+++ b/src/copilot-chat/components/sections/MessageList.tsx
@@ -34,14 +34,14 @@ const MessageList: React.FC<MessageListProps> = ({
 	};
 
 	useLayoutEffect(() => {
-		// 在消息变更后，等待布局完成再滚动，保证切换历史记录时可靠
+		// After message changes, wait for layout to complete before scrolling, ensuring reliable history record switching
 		const timer = setTimeout(() => {
 			scrollToBottom("smooth");
 		}, 0);
 		return () => clearTimeout(timer);
 	}, [messages]);
 
-	// 初次挂载后，延迟滚动一次，避免 Obsidian 启动阶段渲染时机导致未滚动
+	// After first mount, delay scrolling once to avoid races during Obsidian startup rendering
 	useLayoutEffect(() => {
 		const timer = setTimeout(() => {
 			scrollToBottom("auto");
@@ -55,7 +55,7 @@ const MessageList: React.FC<MessageListProps> = ({
 		}
 	}, [isLoading]);
 
-	// 当历史记录加载完成（isLoading -> false）时，滚动到底部
+	// When history finishes loading (isLoading -> false), scroll to bottom
 	useEffect(() => {
 		if (!isLoading) {
 			scrollToBottom("smooth");

--- a/src/copilot-chat/components/sections/ModelSelector.tsx
+++ b/src/copilot-chat/components/sections/ModelSelector.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { concat, cx } from "../../../utils/style";
 import { useCopilotStore } from "../../store/store";
 import { usePlugin } from "../../hooks/usePlugin";
+import { ObsidianIcon } from "../atoms/ObsidianIcon";
 
 const BASE_CLASSNAME = "copilot-chat-model-selector";
 
@@ -14,31 +15,75 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ isAuthenticated }) => {
 	const { selectedModel, availableModels, setSelectedModel } =
 		useCopilotStore();
 
-	const handleModelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const modelValue = e.target.value;
-		const selectedModelOption = availableModels.find(
-			(model) => model.value === modelValue,
-		);
+	const [open, setOpen] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
 
+	useEffect(() => {
+		const handleClickOutside = (e: MouseEvent) => {
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(e.target as Node)
+			) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClickOutside);
+		return () =>
+			document.removeEventListener("mousedown", handleClickOutside);
+	}, []);
+
+	const handleSelect = (value: string) => {
+		const selectedModelOption = availableModels.find(
+			(model) => model.value === value,
+		);
 		if (selectedModelOption) {
 			setSelectedModel(plugin, selectedModelOption);
+			setOpen(false);
 		}
 	};
 
 	return (
-		<div className={concat(BASE_CLASSNAME, "container")}>
-			<select
-				className={cx(concat(BASE_CLASSNAME, "select"))}
-				value={selectedModel.value}
-				onChange={handleModelChange}
+		<div className={concat(BASE_CLASSNAME, "container")} ref={containerRef}>
+			<button
+				className={cx(concat(BASE_CLASSNAME, "button"))}
 				disabled={!isAuthenticated}
+				onClick={() => setOpen((v) => !v)}
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				aria-label="Select model"
 			>
-				{availableModels.map((model) => (
-					<option key={model.value} value={model.value}>
-						{model.label}
-					</option>
-				))}
-			</select>
+				<span style={{ whiteSpace: "nowrap" }}>
+					{selectedModel.label}
+				</span>
+				<ObsidianIcon
+					name="lucide-chevron-down"
+					style={{ marginTop: "2px" }}
+				/>
+			</button>
+
+			{open && (
+				<div className={concat(BASE_CLASSNAME, "menu")} role="listbox">
+					{availableModels.map((model) => (
+						<button
+							key={model.value}
+							role="option"
+							aria-selected={model.value === selectedModel.value}
+							className={cx(
+								concat(BASE_CLASSNAME, "menu-item"),
+								model.value === selectedModel.value
+									? concat(
+										BASE_CLASSNAME,
+										"menu-item-selected",
+									)
+									: "",
+							)}
+							onClick={() => handleSelect(model.value)}
+						>
+							{model.label}
+						</button>
+					))}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/styles.css
+++ b/styles.css
@@ -220,6 +220,7 @@
 
 .copilot-chat-message-list-container {
 	flex: 1;
+	overflow-x: hidden;
 	overflow-y: auto;
 	padding: 10px 0;
 	display: flex;
@@ -233,7 +234,7 @@
 	gap: 5px;
 }
 
-.copilot-chat-message-info {
+.copilot-chat-message-actions {
 	display: flex;
 	align-items: center;
 	gap: 5px;
@@ -256,8 +257,69 @@
 .copilot-chat-input-container {
 	display: flex;
 	flex-direction: column;
-	gap: 5px;
+	gap: 1px;
 	width: 100%;
+	background: var(--background-modifier-form-field);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 5px 10px;
+	margin-top: 8px;
+}
+
+.copilot-chat-input-attachments-bar {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 5px;
+	margin-bottom: 5px;
+}
+
+.copilot-chat-input-attach-button {
+	--icon-size: 1.2em;
+	aspect-ratio: 1 / 1;
+	height: 1.6em;
+	border: 1px solid var(--background-modifier-border);
+	box-shadow: none;
+	cursor: pointer;
+}
+
+.copilot-chat-input-attachment-tag {
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	padding: 2px 6px;
+	font-size: 0.85em;
+	transition:
+		background-color 0.15s ease,
+		color 0.15s ease,
+		border-color 0.15s ease;
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	cursor: pointer;
+	user-select: none;
+}
+
+.copilot-chat-input-attachment-tag:hover {
+	background-color: var(--background-modifier-hover);
+	border-color: var(--interactive-accent);
+	color: var(--text-accent);
+}
+
+.copilot-chat-input-attachment-tag:hover svg {
+	color: var(--text-accent);
+}
+
+button.copilot-chat-input-attachment-remove {
+	height: 1.2em;
+	aspect-ratio: 1 / 1;
+	padding: 0;
+	box-shadow: none;
+	cursor: pointer;
+}
+
+button.copilot-chat-input-attachment-remove:not(:hover) {
+	background: transparent;
 }
 
 .copilot-chat-input-input-container {
@@ -269,10 +331,23 @@
 
 .copilot-chat-input-input {
 	width: 100%;
+	padding: 0;
+	border: none !important;
+	background: transparent !important;
+	outline: none !important;
+	box-shadow: none !important;
 }
 
-.copilot-chat-input-button {
-	height: 60px;
+.copilot-chat-input-actions-bar {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.copilot-chat-input-send-button {
+	box-shadow: none;
+	padding: 4px;
 }
 
 .copilot-chat-header-container {
@@ -280,6 +355,7 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	padding-bottom: 5px;
 }
 
 .copilot-chat-header-title {
@@ -288,7 +364,7 @@
 
 .copilot-chat-header-actions {
 	display: flex;
-	gap: 8px;
+	gap: 1px;
 }
 
 .copilot-chat-header-action-button {
@@ -297,7 +373,6 @@
 	color: var(--text-muted);
 	cursor: pointer;
 	padding: 4px;
-	border-radius: 4px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -312,328 +387,500 @@
  * Model Selector Styles
  ***********************/
 .copilot-chat-model-selector-container {
-	display: flex;
-	align-items: center;
-	margin-bottom: 8px;
 	position: relative;
-	width: 100%;
+	display: inline-block;
 }
 
-.copilot-chat-model-selector-select {
-	width: 100%;
-	background-color: var(--background-secondary);
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 0.9rem;
+.copilot-chat-model-selector-button:not(.clickable-icon) {
+	width: auto;
+	height: 2em;
+	max-width: 300px;
+	padding: 0px 5px;
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	box-shadow: none;
+}
+
+.copilot-chat-model-selector-menu {
+	position: absolute;
+	bottom: 100%;
+	left: -5px;
+	min-width: 100%;
+	z-index: 1000;
+	background: var(--background-primary);
 	border: 1px solid var(--background-modifier-border);
-	color: var(--text-normal);
-	transition: border-color 0.2s ease;
-	appearance: auto;
-	-webkit-appearance: listbox;
-	padding: 0 0 0 4px;
+	border-radius: 4px;
+	box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 8px;
+	overflow: hidden;
 }
 
-.copilot-chat-model-selector-select:focus {
-	outline: none;
-	border-color: var(--interactive-accent);
+.copilot-chat-model-selector-menu-item:not(.clickable-icon) {
+	display: block;
+	width: 100%;
+	text-align: left;
+	padding: 6px 8px;
+	border-radius: 0;
+	background: transparent;
+	cursor: pointer;
+	box-shadow: none;
 }
 
-.copilot-chat-model-selector-select:hover {
-	background-color: var(--background-modifier-hover);
+.copilot-chat-model-selector-menu-item-selected:not(.clickable-icon) {
+	background: var(--background-secondary);
 }
 
-.copilot-chat-model-selector-disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
-}
-
-.copilot-chat-model-selector-select option {
-	background-color: var(--background-primary);
-	color: var(--text-normal);
+.copilot-chat-model-selector-menu-item:not(.clickable-icon):hover {
+	background: var(--background-modifier-hover);
 }
 
 /***********************
  * Conversation Selector Styles
  ***********************/
 .copilot-chat-conversation-selector-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.4);
-  z-index: 1000;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.4);
+	z-index: 1000;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
 .copilot-chat-conversation-selector-container {
-  background-color: var(--background-primary);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  width: 90%;
-  max-width: 500px;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+	background-color: var(--background-primary);
+	border-radius: 8px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	width: 90%;
+	max-width: 500px;
+	max-height: 80vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 }
 
 .copilot-chat-conversation-selector-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--background-modifier-border);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--background-modifier-border);
 }
 
 .copilot-chat-conversation-selector-title {
-  margin: 0;
-  font-size: 1.2rem;
+	margin: 0;
+	font-size: 1.2rem;
 }
 
 .copilot-chat-conversation-selector-close-button {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 0 0 4px 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
+	background: none;
+	border: none;
+	color: var(--text-muted);
+	font-size: 1.5rem;
+	cursor: pointer;
+	padding: 0 0 4px 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
 }
 
 .copilot-chat-conversation-selector-close-button:hover {
-  color: var(--text-normal);
+	color: var(--text-normal);
 }
 
 .copilot-chat-conversation-selector-list {
-  overflow-y: auto;
-  padding: 8px;
-  max-height: 60vh;
+	overflow-y: auto;
+	padding: 8px;
+	max-height: 60vh;
 }
 
 .copilot-chat-conversation-selector-item:hover {
-  background-color: var(--background-modifier-hover);
+	background-color: var(--background-modifier-hover);
 }
 
 .copilot-chat-conversation-selector-item-active {
-  background-color: var(--background-secondary);
-  border-color: var(--interactive-accent);
+	background-color: var(--background-secondary);
+	border-color: var(--interactive-accent);
 }
 
 .copilot-chat-conversation-selector-item-title {
-  font-weight: 500;
-  margin-bottom: 6px;
-  word-break: break-word;
+	font-weight: 500;
+	margin-bottom: 6px;
+	word-break: break-word;
 }
 
 .copilot-chat-conversation-selector-item-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.8rem;
-  color: var(--text-muted);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 0.8rem;
+	color: var(--text-muted);
 }
 
 .copilot-chat-conversation-selector-item-model {
-  background-color: var(--background-secondary);
-  padding: 2px 6px;
-  border-radius: 4px;
+	background-color: var(--background-secondary);
+	padding: 2px 6px;
+	border-radius: 4px;
 }
 
 .copilot-chat-conversation-selector-empty {
-  padding: 24px;
-  text-align: center;
-  color: var(--text-muted);
+	padding: 24px;
+	text-align: center;
+	color: var(--text-muted);
 }
 
 .copilot-chat-conversation-selector-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .copilot-chat-conversation-selector-delete-all-button {
-  background: none;
-  border: 1px solid var(--background-modifier-border);
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 0.8rem;
-  transition: all 0.2s ease;
+	background: none;
+	border: 1px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	cursor: pointer;
+	padding: 4px 8px;
+	border-radius: 4px;
+	font-size: 0.8rem;
+	transition: all 0.2s ease;
 }
 
 .copilot-chat-conversation-selector-delete-all-button:hover {
-  color: var(--text-accent-hover);
-  border-color: var(--text-accent-hover);
-  background-color: var(--background-modifier-hover);
+	color: var(--text-accent-hover);
+	border-color: var(--text-accent-hover);
+	background-color: var(--background-modifier-hover);
 }
 
 .copilot-chat-conversation-selector-item {
-  padding: 12px;
-  border-radius: 4px;
-  margin-bottom: 8px;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+	padding: 12px;
+	border-radius: 4px;
+	margin-bottom: 8px;
+	border: 1px solid transparent;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 }
 
 .copilot-chat-conversation-selector-item-content {
-  flex: 1;
-  min-width: 0;
+	flex: 1;
+	min-width: 0;
 }
 
 .copilot-chat-conversation-selector-delete-button {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition: all 0.2s ease;
-  flex-shrink: 0;
-  margin-left: 8px;
+	background: none;
+	border: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	padding: 6px;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0;
+	transition: all 0.2s ease;
+	flex-shrink: 0;
+	margin-left: 8px;
 }
 
-.copilot-chat-conversation-selector-item:hover .copilot-chat-conversation-selector-delete-button {
-  opacity: 1;
+.copilot-chat-conversation-selector-item:hover
+	.copilot-chat-conversation-selector-delete-button {
+	opacity: 1;
 }
 
 .copilot-chat-conversation-selector-delete-button:hover {
-  color: var(--text-accent-hover);
-  background-color: var(--background-modifier-hover);
+	color: var(--text-accent-hover);
+	background-color: var(--background-modifier-hover);
 }
 
 /***********************
  * File Suggestion Styles
  ***********************/
 .copilot-chat-file-suggestion-container {
-  background-color: var(--background-primary);
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  max-height: 200px;
-  width: 250px;
-  overflow-y: auto;
-  z-index: 1000;
-}
-
-.copilot-chat-file-suggestion-list {
-  padding: 5px 0;
+	position: absolute;
+	bottom: 100%;
+	background-color: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.1);
+	max-height: 300px;
+	width: calc(100% - 20px);
+	overflow-y: auto;
+	z-index: 1000;
 }
 
 .copilot-chat-file-suggestion-item {
-  padding: 5px 10px;
-  cursor: pointer;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 3px;
+	padding: 8px 10px;
+	cursor: pointer;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	background-color: transparent;
+	border-top: 0.5px solid var(--background-modifier-border);
+	border-bottom: 0.5px solid var(--background-modifier-border);
 }
 
 .copilot-chat-file-suggestion-item:hover {
-  background-color: var(--background-modifier-hover);
+	background-color: var(--background-modifier-hover);
 }
 
 .copilot-chat-file-suggestion-item-selected {
-  background-color: var(--background-secondary);
+	background-color: var(--background-secondary);
+}
+
+.copilot-chat-file-suggestion-item-name {
+	font-weight: 500;
+	flex-shrink: 1;
+}
+
+.copilot-chat-file-suggestion-item-path {
+	font-size: 0.8em;
+	color: var(--text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .copilot-chat-file-suggestion-no-results {
-  padding: 10px;
-  text-align: center;
-  color: var(--text-muted);
+	padding: 10px;
+	text-align: center;
+	color: var(--text-muted);
 }
 
 /***********************
  * Message Styles
  ***********************/
-.copilot-chat-message-info {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  position: relative;
+.copilot-chat-message-container .copilot-chat-message-message {
+	word-break: break-word;
 }
 
-.copilot-chat-message-icon {
-  margin-right: 5px;
+.copilot-chat-message-container .copilot-chat-message-message p {
+	white-space: pre-wrap;
 }
 
-.copilot-chat-message-name {
-  flex-grow: 1;
+.copilot-chat-message-user {
+	position: relative;
+	margin-top: 10px;
 }
 
-.copilot-chat-message-copy-button {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.6;
-  transition: opacity 0.2s ease, background-color 0.2s ease;
-  margin-left: auto;
+.copilot-chat-message-user .copilot-chat-message-message {
+	position: relative;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 0 14px;
+	width: 90%;
+	margin-left: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	transition:
+		background-color 0.15s ease,
+		box-shadow 0.15s ease,
+		height 200ms ease;
 }
 
-.copilot-chat-message-copy-button:hover {
-  opacity: 1;
-  background-color: var(--background-modifier-hover);
-  color: var(--text-normal);
+.theme-dark .copilot-chat-message-user .copilot-chat-message-message {
+	background: var(--background-primary-alt, var(--background-secondary));
+}
+
+.copilot-chat-message-user.copilot-chat-message-collapsed
+	.copilot-chat-message-message {
+	overflow-x: hidden;
+}
+
+.copilot-chat-message-toggle-button.copilot-chat-message-expand-collapse-button,
+.copilot-chat-message-toggle-button.copilot-chat-message-expand-collapse-button:hover {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	transform: rotate(180deg);
+	transition: transform 0.2s ease;
+}
+
+.copilot-chat-message-expand-collapse-button.copilot-chat-message-collapsed,
+.copilot-chat-message-expand-collapse-button.copilot-chat-message-collapsed:hover {
+	transform: rotate(0deg);
+}
+
+.copilot-chat-message-collapsed .copilot-chat-message-message:after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 2.2em;
+	background: linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0),
+		var(--background-secondary)
+	);
+	pointer-events: none;
+}
+
+/* Collapsed message hover highlight + pointer */
+.copilot-chat-message-collapsed .copilot-chat-message-message {
+	cursor: pointer;
+}
+
+.copilot-chat-message-collapsed .copilot-chat-message-message:hover {
+	background: var(--background-modifier-hover);
+}
+
+.theme-dark
+	.copilot-chat-message-collapsed
+	.copilot-chat-message-message:after {
+	background: linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0),
+		var(--background-primary-alt, var(--background-secondary))
+	);
+}
+
+/* Toggle button (collapse/expand arrow) */
+.copilot-chat-message-toggle-button {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	background: none;
+	border: none;
+	color: var(--text-muted);
+	padding: 2px;
+	border-radius: 4px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition:
+		background-color 0.15s ease,
+		color 0.15s ease,
+		opacity 0.15s ease;
+	opacity: 0.7;
+}
+
+.copilot-chat-message-toggle-button:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+	opacity: 1;
+}
+
+/* Actions row at bottom */
+.copilot-chat-message-actions {
+	margin-top: 4px;
+	display: flex;
+	gap: 6px;
+	flex-direction: row;
+	justify-content: flex-start;
+}
+
+.copilot-chat-message-user .copilot-chat-message-actions {
+	justify-content: flex-end;
+}
+
+.copilot-chat-message-container
+	.copilot-chat-message-actions
+	button:not(.clickable-icon) {
+	background: none;
+	border: none;
+	box-shadow: none;
+	color: var(--text-muted);
+	padding: 4px;
+	border-radius: 4px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.copilot-chat-message-container
+	.copilot-chat-message-actions
+	button:not(.clickable-icon):hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
 }
 
 .copilot-chat-message-copy-button[title="Copied!"] {
-  opacity: 1;
-  color: var(--text-accent);
-  background-color: var(--background-modifier-success-hover);
+	color: var(--text-accent);
+	background: var(
+		--background-modifier-success-hover,
+		var(--background-modifier-hover)
+	);
+}
+
+.copilot-chat-message-actions {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	position: relative;
+}
+
+.copilot-chat-message-icon {
+	margin-right: 5px;
+}
+
+.copilot-chat-message-name {
+	flex-grow: 1;
+}
+
+.copilot-chat-message-copy-button:hover {
+	opacity: 1;
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.copilot-chat-message-copy-button[title="Copied!"] {
+	opacity: 1;
+	color: var(--text-accent);
+	background-color: var(--background-modifier-success-hover);
 }
 
 /***********************
  * Linked Notes Styles
  ***********************/
-.copilot-chat-message-linked-notes {
-  margin-top: 10px;
-  padding-top: 5px;
-  border-top: 1px solid var(--background-modifier-border);
-}
-
-.copilot-chat-message-linked-notes-title {
-  font-weight: 600;
-  margin-bottom: 5px;
-  color: var(--text-muted);
-  font-size: 0.9em;
-}
-
 .copilot-chat-message-linked-notes-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
+	margin-top: 4px;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	gap: 5px;
+}
+
+.copilot-chat-message-user .copilot-chat-message-linked-notes-list {
+	margin-left: auto;
+	justify-content: flex-end;
 }
 
 .copilot-chat-message-linked-note {
-  background-color: var(--background-secondary);
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.85em;
+	color: var(--text-accent);
+	background-color: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	padding: 2px 6px;
+	font-size: 0.85em;
+	cursor: pointer;
+	transition:
+		background-color 0.15s ease,
+		color 0.15s ease,
+		border-color 0.15s ease;
 }
 
-.copilot-chat-message-linked-note-filename {
-  color: var(--text-accent);
+.copilot-chat-message-linked-note.tag:hover {
+	background-color: var(--background-modifier-hover);
+	border-color: var(--interactive-accent);
 }
 
 /***********************


### PR DESCRIPTION
A personal redesign of the chat UI that I find more usable. If it helps the community, I’d love to upstream it.

- Attachment-aware input with [[Note]] tags and cursor insertion
- Split message components; copy/delete/retry; rendered/raw toggle
- autosizing textarea (1–10 lines)
- Auto-scroll on load and conversation switch; linked notes open/reuse leaf

Screenshots: 
<img width="549" height="981" alt="PixPin_2025-11-30_21-09-28" src="https://github.com/user-attachments/assets/915dbb5d-a62a-42cb-858f-9e29b64884a3" />
<img width="549" height="981" alt="PixPin_2025-11-30_21-10-35" src="https://github.com/user-attachments/assets/91839ca0-c5f6-4231-aec7-bdb885396d49" />
<img width="1491" height="1024" alt="PixPin_2025-11-30_21-11-36" src="https://github.com/user-attachments/assets/72125535-032e-4664-b3c8-4818eac8738d" />
<img width="544" height="562" alt="PixPin_2025-11-30_21-19-59" src="https://github.com/user-attachments/assets/a0b535b9-c0be-4569-ae1d-9e08123ab356" />
