### PR TITLE
feat: improve Copilot model picker

### DIFF
--- a/src/copilot-chat/api/fetchModels.ts
+++ b/src/copilot-chat/api/fetchModels.ts
@@ -1,0 +1,103 @@
+import { requestUrl, RequestUrlResponse } from "obsidian";
+import Logger from "../../helpers/Logger";
+import {
+	canonicalizeModelValue,
+	formatModelLabel,
+	getModelDisplayLabel,
+	isSupportedChatModelValue,
+	ModelOption,
+	sortModels,
+} from "../models";
+
+interface CopilotModelResponse {
+	id?: string;
+	name?: string;
+	display_name?: string;
+}
+
+interface CopilotModelsResponse {
+	data?: CopilotModelResponse[];
+	models?: CopilotModelResponse[];
+	items?: CopilotModelResponse[];
+}
+
+const extractModels = (response: unknown): CopilotModelResponse[] => {
+	if (Array.isArray(response)) {
+		return response.map((entry) =>
+			typeof entry === "string" ? { id: entry } : (entry as CopilotModelResponse),
+		);
+	}
+
+	if (!response || typeof response !== "object") {
+		return [];
+	}
+
+	const payload = response as CopilotModelsResponse & Record<string, unknown>;
+	const collection = [payload.data, payload.models, payload.items].find(
+		(value) => Array.isArray(value),
+	);
+	if (Array.isArray(collection)) {
+		return collection;
+	}
+
+	return [];
+};
+
+const toModelOptions = (response: unknown): ModelOption[] => {
+	const models = extractModels(response);
+
+	const dedupedModels = new Map<string, ModelOption>();
+
+	for (const model of models) {
+		const modelId = model?.id || model?.name || model?.display_name;
+		if (!modelId) {
+			continue;
+		}
+
+		if (!isSupportedChatModelValue(modelId)) {
+			continue;
+		}
+
+		const canonicalValue = canonicalizeModelValue(modelId);
+
+		const discoveredModel: ModelOption = {
+			label: formatModelLabel(canonicalValue),
+			value: canonicalValue,
+		};
+
+		dedupedModels.set(canonicalValue, {
+			...discoveredModel,
+			label:
+				model.display_name ||
+				model.name ||
+				getModelDisplayLabel(discoveredModel),
+		});
+	}
+
+	return sortModels(Array.from(dedupedModels.values()));
+};
+
+export const fetchModels = async (
+	accessToken: string,
+): Promise<ModelOption[]> => {
+	try {
+		const response: RequestUrlResponse = await requestUrl({
+			url: "https://api.githubcopilot.com/models",
+			method: "GET",
+			headers: {
+				Accept: "application/json",
+				"editor-version": "vscode/1.80.1",
+				Authorization: `Bearer ${accessToken}`,
+			},
+		});
+
+		if (response.status !== 200) {
+			throw new Error(`Failed to fetch models: ${response.status}`);
+		}
+
+		return toModelOptions(await response.json);
+	} catch (error) {
+		Logger.getInstance().error(`Error fetching models: ${error}`);
+		throw new Error("Failed to fetch models");
+	}
+};

--- a/src/copilot-chat/api/index.ts
+++ b/src/copilot-chat/api/index.ts
@@ -1,3 +1,4 @@
 export { fetchDeviceCode, type DeviceCodeResponse } from "./fetchDeviceCode";
 export { fetchPAT, type PATResponse } from "./fetchPAT";
+export { fetchModels } from "./fetchModels";
 export { fetchToken, type TokenResponse } from "./fetchToken";

--- a/src/copilot-chat/api/sendMessage.ts
+++ b/src/copilot-chat/api/sendMessage.ts
@@ -1,9 +1,11 @@
 import { requestUrl, RequestUrlResponse } from "obsidian";
 import Logger from "../../helpers/Logger";
+import { ReasoningEffort } from "../models";
 
 export interface SendMessageRequest {
 	intent: boolean;
 	model: string;
+	reasoning_effort?: ReasoningEffort;
 	temperature: number;
 	top_p: number;
 	n: number;

--- a/src/copilot-chat/components/sections/ModelSelector.tsx
+++ b/src/copilot-chat/components/sections/ModelSelector.tsx
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { concat, cx } from "../../../utils/style";
 import { useCopilotStore } from "../../store/store";
 import { usePlugin } from "../../hooks/usePlugin";
+import {
+	formatReasoningEffortLabel,
+	getModelCompactMeta,
+	getModelDisplayLabel,
+	getModelMetaSummary,
+	groupModelsForPicker,
+	ReasoningEffort,
+	supportsReasoningEffort,
+} from "../../models";
 
 const BASE_CLASSNAME = "copilot-chat-model-selector";
 
@@ -11,34 +20,159 @@ interface ModelSelectorProps {
 
 const ModelSelector: React.FC<ModelSelectorProps> = ({ isAuthenticated }) => {
 	const plugin = usePlugin();
-	const { selectedModel, availableModels, setSelectedModel } =
+	const {
+		selectedModel,
+		availableModels,
+		reasoningEffort,
+		setSelectedModel,
+		setReasoningEffort,
+	} =
 		useCopilotStore();
+	const modelMenuRef = useRef<HTMLDivElement>(null);
+	const effortMenuRef = useRef<HTMLDivElement>(null);
+	const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
+	const [isEffortMenuOpen, setIsEffortMenuOpen] = useState(false);
 
-	const handleModelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const modelValue = e.target.value;
-		const selectedModelOption = availableModels.find(
-			(model) => model.value === modelValue,
-		);
+	const reasoningEffortSupported = supportsReasoningEffort(selectedModel);
+	const modelGroups = groupModelsForPicker(availableModels);
+	const selectedModelCompactMeta = getModelCompactMeta(selectedModel);
 
-		if (selectedModelOption) {
-			setSelectedModel(plugin, selectedModelOption);
-		}
-	};
+	useEffect(() => {
+		const handleOutsideClick = (event: MouseEvent) => {
+			if (
+				modelMenuRef.current &&
+				!modelMenuRef.current.contains(event.target as Node)
+			) {
+				setIsModelMenuOpen(false);
+			}
+
+			if (
+				effortMenuRef.current &&
+				!effortMenuRef.current.contains(event.target as Node)
+			) {
+				setIsEffortMenuOpen(false);
+			}
+		};
+
+		document.addEventListener("mousedown", handleOutsideClick);
+		return () => document.removeEventListener("mousedown", handleOutsideClick);
+	}, []);
 
 	return (
 		<div className={concat(BASE_CLASSNAME, "container")}>
-			<select
-				className={cx(concat(BASE_CLASSNAME, "select"))}
-				value={selectedModel.value}
-				onChange={handleModelChange}
-				disabled={!isAuthenticated}
-			>
-				{availableModels.map((model) => (
-					<option key={model.value} value={model.value}>
-						{model.label}
-					</option>
-				))}
-			</select>
+			<div className={concat(BASE_CLASSNAME, "menu-group")} ref={modelMenuRef}>
+				<button
+					type="button"
+					className={cx(concat(BASE_CLASSNAME, "button"))}
+					onClick={() =>
+						setIsModelMenuOpen((current) =>
+							isAuthenticated ? !current : false,
+						)
+					}
+					disabled={!isAuthenticated}
+				>
+					<div className={concat(BASE_CLASSNAME, "button-main")}>
+						<span className={concat(BASE_CLASSNAME, "button-label")}>
+							{getModelDisplayLabel(selectedModel)}
+						</span>
+						{selectedModelCompactMeta && (
+							<span className={concat(BASE_CLASSNAME, "button-meta")}>
+								{selectedModelCompactMeta}
+							</span>
+						)}
+					</div>
+				</button>
+				{isModelMenuOpen && (
+					<div className={concat(BASE_CLASSNAME, "menu")}>
+						{modelGroups.map((group) => (
+							<div key={group.label} className={concat(BASE_CLASSNAME, "section")}>
+								<div className={concat(BASE_CLASSNAME, "section-title")}>
+									{group.label}
+								</div>
+								{group.models.map((model) => {
+									const compactMeta = getModelCompactMeta(model);
+
+									return (
+										<button
+											type="button"
+											key={model.value}
+											className={cx(
+												concat(BASE_CLASSNAME, "option"),
+												model.value === selectedModel.value
+													? concat(BASE_CLASSNAME, "option-active")
+													: "",
+											)}
+											onClick={() => {
+												setSelectedModel(plugin, model);
+												setIsModelMenuOpen(false);
+											}}
+										>
+											<span className={concat(BASE_CLASSNAME, "option-label")}>
+												{getModelDisplayLabel(model)}
+											</span>
+											{compactMeta && (
+												<span className={concat(BASE_CLASSNAME, "option-meta")}>
+													{compactMeta}
+												</span>
+											)}
+										</button>
+									);
+								})}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+			<div className={concat(BASE_CLASSNAME, "meta")}>
+				<div className={concat(BASE_CLASSNAME, "meta-text")}>
+					{getModelMetaSummary(selectedModel) || "No model metadata available"}
+				</div>
+				<div className={concat(BASE_CLASSNAME, "effort-group")} ref={effortMenuRef}>
+					<button
+						type="button"
+						className={cx(concat(BASE_CLASSNAME, "effort-button"))}
+						onClick={() =>
+							setIsEffortMenuOpen((current) =>
+								reasoningEffortSupported && isAuthenticated
+									? !current
+									: false,
+							)
+						}
+						disabled={!isAuthenticated || !reasoningEffortSupported}
+					>
+						Reasoning: {formatReasoningEffortLabel(reasoningEffort)}
+					</button>
+					{isEffortMenuOpen && reasoningEffortSupported && (
+						<div className={concat(BASE_CLASSNAME, "effort-menu")}>
+							{(["low", "medium", "high"] as ReasoningEffort[]).map(
+								(effort) => (
+									<button
+										type="button"
+										key={effort}
+										className={cx(
+											concat(BASE_CLASSNAME, "effort-option"),
+											effort === reasoningEffort
+												? concat(BASE_CLASSNAME, "effort-option-active")
+												: "",
+										)}
+										onClick={() => {
+											setReasoningEffort(plugin, effort);
+											setIsEffortMenuOpen(false);
+										}}
+									>
+										{formatReasoningEffortLabel(effort)}
+									</button>
+								),
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+			{!reasoningEffortSupported && (
+				<div className={concat(BASE_CLASSNAME, "effort-note")}>
+					Reasoning effort is currently exposed only for GPT-5 family and compatible reasoning models.
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/copilot-chat/layouts/MainLayout.tsx
+++ b/src/copilot-chat/layouts/MainLayout.tsx
@@ -20,12 +20,35 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
 	// const reset = useAuthStore((state) => state.reset);
 
 	useEffect(() => {
-		if (plugin) {
-			initAuthService(plugin);
-			initMessageService(plugin);
-			initConversationService(plugin);
+		if (!plugin) {
+			return;
 		}
-	}, [plugin, initAuthService, initMessageService, initConversationService]);
+
+		let cancelled = false;
+
+		const initialize = async () => {
+			await initAuthService(plugin);
+			if (cancelled) {
+				return;
+			}
+
+			await initConversationService(plugin);
+		};
+
+		initialize();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [plugin, initAuthService, initConversationService]);
+
+	useEffect(() => {
+		if (!plugin || !isAuth) {
+			return;
+		}
+
+		initMessageService(plugin);
+	}, [plugin, isAuth, initMessageService]);
 
 	return (
 		<div className="copilot-chat-container">

--- a/src/copilot-chat/models.ts
+++ b/src/copilot-chat/models.ts
@@ -1,0 +1,447 @@
+export type ReasoningEffort = "low" | "medium" | "high";
+
+export interface ModelOption {
+	label: string;
+	value: string;
+	multiplier?: string;
+	tier?: "Medium" | "High" | "Xhigh";
+	preview?: boolean;
+	supportsReasoningEffort?: boolean;
+}
+
+export interface ModelGroup {
+	label: string;
+	models: ModelOption[];
+}
+
+const modelLabelOverrides: Record<string, string> = {
+	"gpt-4o": "GPT-4o",
+	"gpt-4.1": "GPT-4.1",
+	"gpt-5-mini": "GPT-5 mini",
+	"gpt-5.1": "GPT-5.1",
+	"gpt-5.1-codex": "GPT-5.1-Codex",
+	"gpt-5.1-codex-mini": "GPT-5.1-Codex-Mini",
+	"gpt-5.1-codex-max": "GPT-5.1-Codex-Max",
+	"gpt-5.2": "GPT-5.2",
+	"gpt-5.2-codex": "GPT-5.2-Codex",
+	"gpt-5.3-codex": "GPT-5.3-Codex",
+	"gpt-5.4": "GPT-5.4",
+	"gpt-5.4-mini": "GPT-5.4 mini",
+	"claude-haiku-4.5": "Claude Haiku 4.5",
+	"claude-sonnet-4": "Claude Sonnet 4",
+	"claude-sonnet-4.5": "Claude Sonnet 4.5",
+	"claude-sonnet-4.6": "Claude Sonnet 4.6",
+	"claude-opus-4.5": "Claude Opus 4.5",
+	"claude-opus-4.6": "Claude Opus 4.6",
+	"claude-opus-4.6-fast": "Claude Opus 4.6 (fast mode)",
+	"gemini-2.5-pro": "Gemini 2.5 Pro",
+	"gemini-3-flash-preview": "Gemini 3 Flash",
+	"gemini-3-pro-preview": "Gemini 3 Pro",
+	"gemini-3.1-pro-preview": "Gemini 3.1 Pro",
+	"grok-code-fast-1": "Grok Code Fast 1",
+	"raptor-mini": "Raptor mini",
+	"goldeneye": "Goldeneye",
+};
+
+const legacyModelAliases: Record<string, string> = {
+	"gpt-4o-2024-08-06": "gpt-4o",
+	"gpt-4.1-2025-04-14": "gpt-4.1",
+	"gemini-3-pro": "gemini-3-pro-preview",
+	"gemini-3-pro-preview": "gemini-3-pro-preview",
+	"gemini-3-flash": "gemini-3-flash-preview",
+	"gemini-3-flash-preview": "gemini-3-flash-preview",
+	"gemini-3.1-pro": "gemini-3.1-pro-preview",
+	"gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+	"claude-opus-4.6-fast-mode": "claude-opus-4.6-fast",
+	"claude-opus-4.6-fast-mode-preview": "claude-opus-4.6-fast",
+	"claude-opus-4.6-fast-preview": "claude-opus-4.6-fast",
+};
+
+export const canonicalizeModelValue = (value: string): string => {
+	return legacyModelAliases[value] || value;
+};
+
+export const defaultModels: ModelOption[] = [
+	{ label: "GPT-4o", value: "gpt-4o", multiplier: "0x" },
+	{ label: "GPT-4.1", value: "gpt-4.1", multiplier: "0x" },
+	{
+		label: "GPT-5 mini",
+		value: "gpt-5-mini",
+		multiplier: "0x",
+		tier: "Medium",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.1",
+		value: "gpt-5.1",
+		multiplier: "1x",
+		tier: "Medium",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.1-Codex",
+		value: "gpt-5.1-codex",
+		multiplier: "1x",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.1-Codex-Mini",
+		value: "gpt-5.1-codex-mini",
+		multiplier: "0.33x",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.1-Codex-Max",
+		value: "gpt-5.1-codex-max",
+		multiplier: "1x",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.2",
+		value: "gpt-5.2",
+		multiplier: "1x",
+		tier: "Medium",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.2-Codex",
+		value: "gpt-5.2-codex",
+		multiplier: "1x",
+		tier: "Medium",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.3-Codex",
+		value: "gpt-5.3-codex",
+		multiplier: "1x",
+		tier: "Xhigh",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.4",
+		value: "gpt-5.4",
+		multiplier: "1x",
+		tier: "High",
+		supportsReasoningEffort: true,
+	},
+	{
+		label: "GPT-5.4 mini",
+		value: "gpt-5.4-mini",
+		multiplier: "0.33x",
+		tier: "High",
+		supportsReasoningEffort: true,
+	},
+	{ label: "Claude Haiku 4.5", value: "claude-haiku-4.5", multiplier: "0.33x" },
+	{ label: "Claude Sonnet 4", value: "claude-sonnet-4", multiplier: "1x" },
+	{ label: "Claude Sonnet 4.5", value: "claude-sonnet-4.5", multiplier: "1x" },
+	{
+		label: "Claude Sonnet 4.6",
+		value: "claude-sonnet-4.6",
+		multiplier: "1x",
+		tier: "High",
+	},
+	{ label: "Claude Opus 4.5", value: "claude-opus-4.5", multiplier: "3x" },
+	{
+		label: "Claude Opus 4.6",
+		value: "claude-opus-4.6",
+		multiplier: "3x",
+		tier: "High",
+	},
+	{
+		label: "Claude Opus 4.6 (fast mode)",
+		value: "claude-opus-4.6-fast",
+		multiplier: "30x",
+		tier: "High",
+		preview: true,
+	},
+	{ label: "Gemini 2.5 Pro", value: "gemini-2.5-pro", multiplier: "1x" },
+	{
+		label: "Gemini 3 Flash",
+		value: "gemini-3-flash-preview",
+		multiplier: "0.33x",
+		preview: true,
+	},
+	{
+		label: "Gemini 3.1 Pro",
+		value: "gemini-3.1-pro-preview",
+		multiplier: "1x",
+		preview: true,
+	},
+	{ label: "Grok Code Fast 1", value: "grok-code-fast-1", multiplier: "0.25x" },
+	{
+		label: "Raptor mini",
+		value: "raptor-mini",
+		multiplier: "0x",
+		preview: true,
+	},
+	{
+		label: "Goldeneye",
+		value: "goldeneye",
+		multiplier: "1x",
+		preview: true,
+	},
+];
+
+const knownChatModelValues = new Set(defaultModels.map((model) => model.value));
+
+const featuredModelOrder = [
+	"claude-opus-4.6",
+	"claude-sonnet-4.6",
+	"gpt-4o",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+];
+
+const featuredModelValues = new Set(featuredModelOrder);
+const catalogOrder = new Map(
+	defaultModels.map((model, index) => [canonicalizeModelValue(model.value), index]),
+);
+
+export const DEFAULT_SELECTED_MODEL_VALUE = "gpt-5.2";
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+
+export const getPreferredDefaultModel = (
+	models: ModelOption[] = defaultModels,
+): ModelOption => {
+	return (
+		models.find((model) => model.value === DEFAULT_SELECTED_MODEL_VALUE) ||
+		models[0]
+	);
+};
+
+export const formatModelLabel = (modelId: string): string => {
+	if (modelLabelOverrides[modelId]) {
+		return modelLabelOverrides[modelId];
+	}
+
+	return modelId
+		.split("-")
+		.map((part) => {
+			if (part.toLowerCase() === "gpt") return "GPT";
+			if (part.toLowerCase() === "claude") return "Claude";
+			if (part.toLowerCase() === "gemini") return "Gemini";
+			if (part.toLowerCase() === "grok") return "Grok";
+			if (part.toLowerCase() === "code") return "Code";
+			if (part.toLowerCase() === "fast") return "Fast";
+			if (part.toLowerCase() === "mini") return "mini";
+			if (part.toLowerCase() === "max") return "Max";
+			if (part.toLowerCase() === "codex") return "Codex";
+			if (/^\d/.test(part)) return part;
+
+			return part.charAt(0).toUpperCase() + part.slice(1);
+		})
+		.join(" ");
+};
+
+export const sortModels = (models: ModelOption[]): ModelOption[] => {
+	return [...models].sort((left, right) =>
+		left.label.localeCompare(right.label, undefined, {
+			numeric: true,
+			sensitivity: "base",
+		}),
+	);
+};
+
+export const mergeModelOptions = (
+	knownModels: ModelOption[],
+	discoveredModels: ModelOption[],
+): ModelOption[] => {
+	const merged = new Map<string, ModelOption>();
+
+	for (const model of knownModels) {
+		merged.set(canonicalizeModelValue(model.value), model);
+	}
+
+	for (const model of discoveredModels) {
+		const normalizedValue = canonicalizeModelValue(model.value);
+		const existing = merged.get(normalizedValue);
+
+		if (existing) {
+			merged.set(normalizedValue, {
+				...existing,
+				...model,
+				value: existing.value,
+				label: existing.label,
+			});
+			continue;
+		}
+
+		merged.set(normalizedValue, {
+			...model,
+			value: normalizedValue,
+			label: model.label || formatModelLabel(normalizedValue),
+		});
+	}
+
+	return sortModels(Array.from(merged.values()));
+};
+
+export const getModelDisplayLabel = (model: ModelOption): string => {
+	return `${model.label}${model.preview ? " (Preview)" : ""}`;
+};
+
+export const getModelPickerLabel = (model: ModelOption): string => {
+	const parts = [getModelDisplayLabel(model)];
+	if (model.tier) {
+		parts.push(model.tier);
+	}
+	if (model.multiplier) {
+		parts.push(model.multiplier);
+	}
+	return parts.join(" - ");
+};
+
+export const getModelMetaSummary = (model: ModelOption): string => {
+	const parts: string[] = [];
+	if (model.tier) {
+		parts.push(`Tier: ${model.tier}`);
+	}
+	if (model.multiplier) {
+		parts.push(`Premium multiplier: ${model.multiplier}`);
+	}
+	if (model.preview) {
+		parts.push("Preview");
+	}
+	return parts.join(" | ");
+};
+
+export const getModelCompactMeta = (model: ModelOption): string => {
+	const parts: string[] = [];
+	if (model.tier) {
+		parts.push(model.tier);
+	}
+	if (model.multiplier) {
+		parts.push(model.multiplier);
+	}
+	return parts.join(" · ");
+};
+
+export const formatReasoningEffortLabel = (effort: ReasoningEffort): string => {
+	if (effort === "low") {
+		return "Low";
+	}
+
+	if (effort === "high") {
+		return "High";
+	}
+
+	return "Medium";
+};
+
+export const supportsReasoningEffort = (model: ModelOption): boolean => {
+	return !!model.supportsReasoningEffort;
+};
+
+export const groupModelsForPicker = (models: ModelOption[]): ModelGroup[] => {
+	const orderedModels = [...models].sort((left, right) => {
+		const leftValue = canonicalizeModelValue(left.value);
+		const rightValue = canonicalizeModelValue(right.value);
+		const leftFeatured = featuredModelValues.has(leftValue);
+		const rightFeatured = featuredModelValues.has(rightValue);
+
+		if (leftFeatured && rightFeatured) {
+			return (
+				featuredModelOrder.indexOf(leftValue) -
+				featuredModelOrder.indexOf(rightValue)
+			);
+		}
+
+		if (leftFeatured !== rightFeatured) {
+			return leftFeatured ? -1 : 1;
+		}
+
+		const leftOrder = catalogOrder.get(leftValue);
+		const rightOrder = catalogOrder.get(rightValue);
+		if (leftOrder !== undefined && rightOrder !== undefined) {
+			return leftOrder - rightOrder;
+		}
+
+		if (leftOrder !== undefined) {
+			return -1;
+		}
+
+		if (rightOrder !== undefined) {
+			return 1;
+		}
+
+		return left.label.localeCompare(right.label, undefined, {
+			numeric: true,
+			sensitivity: "base",
+		});
+	});
+
+	const featuredModels = orderedModels.filter((model) =>
+		featuredModelValues.has(canonicalizeModelValue(model.value)),
+	);
+	const otherModels = orderedModels.filter(
+		(model) => !featuredModelValues.has(canonicalizeModelValue(model.value)),
+	);
+
+	const groups: ModelGroup[] = [];
+	if (featuredModels.length > 0) {
+		groups.push({ label: "Featured models", models: featuredModels });
+	}
+
+	if (otherModels.length > 0) {
+		groups.push({ label: "Other models", models: otherModels });
+	}
+
+	return groups;
+};
+
+export const isSupportedChatModelValue = (value: string): boolean => {
+	const normalizedValue = canonicalizeModelValue(value);
+
+	if (knownChatModelValues.has(normalizedValue)) {
+		return true;
+	}
+
+	if (/embedding|ada|inference/i.test(normalizedValue)) {
+		return false;
+	}
+
+	if (/^gpt-3\.5/i.test(normalizedValue)) {
+		return false;
+	}
+
+	if (/^gpt-4($|-turbo)/i.test(normalizedValue)) {
+		return false;
+	}
+
+	if (/^gpt-4o-mini$/i.test(normalizedValue)) {
+		return false;
+	}
+
+	return /^(gpt-5([.-]|$)|claude(-|$)|gemini(-|$)|grok(-|$)|raptor(-|$)|goldeneye$|gpt-4o$|gpt-4\.1$)/i.test(
+		normalizedValue,
+	);
+};
+
+export const normalizeSelectedModel = (
+	models: ModelOption[],
+	selectedModel?: ModelOption,
+): ModelOption | null => {
+	if (!selectedModel) {
+		return null;
+	}
+
+	const exactMatch = models.find(
+		(model) => model.value === selectedModel.value,
+	);
+	if (exactMatch) {
+		return exactMatch;
+	}
+
+	const aliasedValue = canonicalizeModelValue(selectedModel.value);
+	if (aliasedValue) {
+		const aliasMatch = models.find((model) => model.value === aliasedValue);
+		if (aliasMatch) {
+			return aliasMatch;
+		}
+	}
+
+	const labelMatch = models.find(
+		(model) => model.label.toLowerCase() === selectedModel.label.toLowerCase(),
+	);
+	return labelMatch || null;
+};

--- a/src/copilot-chat/store/slices/auth.tsx
+++ b/src/copilot-chat/store/slices/auth.tsx
@@ -24,7 +24,7 @@ export interface AuthSlice {
 	deviceCodeData: DeviceCodeResponse | null;
 	storageInfo: { method: string; secure: boolean } | null;
 
-	initAuthService: (plugin: CopilotPlugin) => void;
+	initAuthService: (plugin: CopilotPlugin) => Promise<void>;
 	checkAndRefreshToken: (plugin: CopilotPlugin) => Promise<string | null>;
 
 	setDeviceCode: (plugin: CopilotPlugin, code: string) => void;

--- a/src/copilot-chat/store/slices/conversation.tsx
+++ b/src/copilot-chat/store/slices/conversation.tsx
@@ -4,7 +4,8 @@ import CopilotPlugin from "../../../main";
 import Vault from "../../../helpers/Vault";
 import File from "../../../helpers/File";
 import Logger from "../../../helpers/Logger";
-import { MessageData, ModelOption } from "./message";
+import { ModelOption } from "../../models";
+import { MessageData } from "./message";
 import { existsSync } from "fs";
 
 export interface Conversation {
@@ -21,7 +22,9 @@ export interface ConversationSlice {
 	activeConversationId: string | null;
 	isLoadingConversations: boolean;
 
-	initConversationService: (plugin: CopilotPlugin | undefined) => void;
+	initConversationService: (
+		plugin: CopilotPlugin | undefined,
+	) => Promise<void>;
 	loadConversations: (plugin: CopilotPlugin) => Promise<void>;
 	saveConversations: (plugin: CopilotPlugin) => Promise<void>;
 

--- a/src/copilot-chat/store/slices/message.tsx
+++ b/src/copilot-chat/store/slices/message.tsx
@@ -1,7 +1,18 @@
 import { StateCreator } from "zustand";
 import { Notice } from "obsidian";
 import CopilotPlugin from "../../../main";
+import { fetchModels } from "../../api";
 import { SendMessageRequest, sendMessage } from "../../api/sendMessage";
+import {
+	DEFAULT_REASONING_EFFORT,
+	defaultModels,
+	getPreferredDefaultModel,
+	mergeModelOptions,
+	ModelOption,
+	normalizeSelectedModel,
+	ReasoningEffort,
+	supportsReasoningEffort,
+} from "../../models";
 
 export interface MessageData {
 	id: string;
@@ -15,19 +26,17 @@ export interface MessageData {
 	}[];
 }
 
-export interface ModelOption {
-	label: string;
-	value: string;
-}
-
 export interface MessageSlice {
 	messages: MessageData[];
 	isLoading: boolean;
 	error: string | null;
 	selectedModel: ModelOption;
 	availableModels: ModelOption[];
+	reasoningEffort: ReasoningEffort;
 
-	initMessageService: (plugin: CopilotPlugin | undefined) => void;
+	initMessageService: (
+		plugin: CopilotPlugin | undefined,
+	) => Promise<void>;
 	sendMessage: (
 		plugin: CopilotPlugin | undefined,
 		apiMessage: string,
@@ -39,21 +48,11 @@ export interface MessageSlice {
 		plugin: CopilotPlugin | undefined,
 		model: ModelOption,
 	) => void;
+	setReasoningEffort: (
+		plugin: CopilotPlugin | undefined,
+		effort: ReasoningEffort,
+	) => void;
 }
-
-export const defaultModels: ModelOption[] = [
-	{ label: "GPT-4o", value: "gpt-4o-2024-08-06" },
-	{ label: "GPT-4.1", value: "gpt-4.1-2025-04-14" },
-	{ label: "GPT-5", value: "gpt-5" },
-	{ label: "GPT-5-mini", value: "gpt-5-mini" },
-	{ label: "GPT-5.2", value: "gpt-5.2" },
-	{ label: "Claude Haiku 4.5", value: "claude-haiku-4.5" },
-	{ label: "Claude Sonnet 4", value: "claude-sonnet-4" },
-	{ label: "Claude Sonnet 4.5", value: "claude-sonnet-4.5" },
-	{ label: "Gemini 2.5 Pro", value: "gemini-2.5-pro" },
-	{ label: "Gemini 3 Pro", value: "gemini-3-pro-preview" },
-	{ label: "Gemini 3 Flash", value: "gemini-3-flash-preview" },
-];
 
 export const createMessageSlice: StateCreator<
 	any, // We use any here as we'll properly type it in the store.ts
@@ -64,15 +63,62 @@ export const createMessageSlice: StateCreator<
 	messages: [],
 	isLoading: false,
 	error: null,
-	selectedModel: defaultModels[0],
+	selectedModel: getPreferredDefaultModel(),
 	availableModels: defaultModels,
+	reasoningEffort: DEFAULT_REASONING_EFFORT,
 
-	initMessageService: (plugin: CopilotPlugin | undefined) => {
-		if (plugin && plugin.settings.chatSettings) {
-			const { selectedModel } = plugin.settings.chatSettings;
-			if (selectedModel) {
-				set({ selectedModel });
+	initMessageService: async (plugin: CopilotPlugin | undefined) => {
+		if (!plugin) {
+			return;
+		}
+
+		const storedModel = plugin.settings.chatSettings?.selectedModel;
+		const storedReasoningEffort =
+			plugin.settings.chatSettings?.reasoningEffort ||
+			DEFAULT_REASONING_EFFORT;
+		const fallbackSelectedModel =
+			normalizeSelectedModel(defaultModels, storedModel) ||
+			getPreferredDefaultModel(defaultModels);
+
+		set({
+			availableModels: defaultModels,
+			selectedModel: fallbackSelectedModel,
+			reasoningEffort: storedReasoningEffort,
+		});
+
+		const accessToken = await get().checkAndRefreshToken(plugin);
+		if (!accessToken) {
+			return;
+		}
+
+		try {
+			const discoveredModels = await fetchModels(accessToken);
+			const availableModels = mergeModelOptions(
+				defaultModels,
+				discoveredModels,
+			);
+			if (availableModels.length === 0) {
+				return;
 			}
+
+			const selectedModel =
+				normalizeSelectedModel(availableModels, storedModel) ||
+				getPreferredDefaultModel(availableModels);
+
+			set({
+				availableModels,
+				selectedModel,
+			});
+
+			if (
+				!storedModel ||
+				storedModel.value !== selectedModel.value ||
+				storedModel.label !== selectedModel.label
+			) {
+				get().setSelectedModel(plugin, selectedModel);
+			}
+		} catch (error) {
+			console.error("Failed to fetch Copilot models:", error);
 		}
 	},
 	sendMessage: async (
@@ -161,6 +207,9 @@ export const createMessageSlice: StateCreator<
 			const requestData: SendMessageRequest = {
 				intent: false,
 				model: get().selectedModel.value,
+				...(supportsReasoningEffort(get().selectedModel)
+					? { reasoning_effort: get().reasoningEffort }
+					: {}),
 				temperature: 0,
 				top_p: 1,
 				n: 1,
@@ -226,6 +275,10 @@ export const createMessageSlice: StateCreator<
 		});
 
 		if (plugin) {
+			const reasoningEffort =
+				plugin.settings.chatSettings?.reasoningEffort ||
+				DEFAULT_REASONING_EFFORT;
+
 			if (!plugin.settings.chatSettings) {
 				plugin.settings.chatSettings = {
 					deviceCode: null,
@@ -235,6 +288,7 @@ export const createMessageSlice: StateCreator<
 						expiresAt: null,
 					},
 					selectedModel: model,
+					reasoningEffort,
 				};
 			} else {
 				plugin.settings.chatSettings.selectedModel = model;
@@ -244,5 +298,37 @@ export const createMessageSlice: StateCreator<
 				console.error("Failed to save selected model:", error);
 			});
 		}
+	},
+
+	setReasoningEffort: (
+		plugin: CopilotPlugin | undefined,
+		effort: ReasoningEffort,
+	) => {
+		set({
+			reasoningEffort: effort,
+		});
+
+		if (!plugin) {
+			return;
+		}
+
+		if (!plugin.settings.chatSettings) {
+			plugin.settings.chatSettings = {
+				deviceCode: null,
+				pat: null,
+				accessToken: {
+					token: null,
+					expiresAt: null,
+				},
+				selectedModel: get().selectedModel,
+				reasoningEffort: effort,
+			};
+		} else {
+			plugin.settings.chatSettings.reasoningEffort = effort;
+		}
+
+		plugin.saveData(plugin.settings).catch((error) => {
+			console.error("Failed to save reasoning effort:", error);
+		});
 	},
 });

--- a/src/settings/CopilotPluginSettingTab.tsx
+++ b/src/settings/CopilotPluginSettingTab.tsx
@@ -11,7 +11,12 @@ import Logger from "../helpers/Logger";
 import File from "../helpers/File";
 import Json from "../helpers/Json";
 import Vault from "../helpers/Vault";
-import { defaultModels } from "../copilot-chat/store/slices/message";
+import {
+	DEFAULT_REASONING_EFFORT,
+	defaultModels,
+	getPreferredDefaultModel,
+	ReasoningEffort,
+} from "../copilot-chat/models";
 
 export interface SettingsObserver {
 	onSettingsUpdate(): Promise<void>;
@@ -38,6 +43,7 @@ export type CopilotChatSettings = {
 		label: string;
 		value: string;
 	};
+	reasoningEffort?: ReasoningEffort;
 };
 
 export interface CopilotPluginSettings {
@@ -90,7 +96,8 @@ export const DEFAULT_SETTINGS: CopilotPluginSettings = {
 			token: null,
 			expiresAt: null,
 		},
-		selectedModel: defaultModels[4],
+		selectedModel: getPreferredDefaultModel(defaultModels),
+		reasoningEffort: DEFAULT_REASONING_EFFORT,
 	},
 	systemPrompt:
 		"You are GitHub Copilot, an AI assistant. You are helping the user with their tasks in Obsidian.",

--- a/styles.css
+++ b/styles.css
@@ -313,7 +313,9 @@
  ***********************/
 .copilot-chat-model-selector-container {
 	display: flex;
-	align-items: center;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 6px;
 	margin-bottom: 8px;
 	position: relative;
 	width: 100%;
@@ -350,6 +352,189 @@
 .copilot-chat-model-selector-select option {
 	background-color: var(--background-primary);
 	color: var(--text-normal);
+}
+
+.copilot-chat-model-selector-menu-group {
+	position: relative;
+	width: 100%;
+}
+
+.copilot-chat-model-selector-button {
+	width: 100%;
+	background-color: var(--background-secondary);
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	color: var(--text-normal);
+	transition: border-color 0.2s ease;
+	padding: 8px 10px;
+	cursor: pointer;
+	text-align: left;
+}
+
+.copilot-chat-model-selector-button:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+.copilot-chat-model-selector-button-main {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+}
+
+.copilot-chat-model-selector-button-label {
+	font-size: 0.95rem;
+	color: var(--text-normal);
+}
+
+.copilot-chat-model-selector-button-meta {
+	font-size: 0.8rem;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.copilot-chat-model-selector-menu {
+	position: absolute;
+	top: calc(100% + 6px);
+	left: 0;
+	right: 0;
+	max-height: 420px;
+	overflow-y: auto;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+	padding: 8px;
+	z-index: 25;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.copilot-chat-model-selector-section {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.copilot-chat-model-selector-section-title {
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--text-faint);
+	padding: 2px 6px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.copilot-chat-model-selector-option {
+	width: 100%;
+	background: transparent;
+	border: none;
+	border-radius: 6px;
+	color: var(--text-normal);
+	padding: 10px 12px;
+	text-align: left;
+	cursor: pointer;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+}
+
+.copilot-chat-model-selector-option:hover {
+	background: var(--background-modifier-hover);
+}
+
+.copilot-chat-model-selector-option-active {
+	background: var(--background-modifier-hover);
+	outline: 1px solid var(--interactive-accent);
+}
+
+.copilot-chat-model-selector-option-label {
+	color: var(--text-normal);
+	min-width: 0;
+}
+
+.copilot-chat-model-selector-option-meta {
+	font-size: 0.8rem;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.copilot-chat-model-selector-meta {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	font-size: 0.8rem;
+	color: var(--text-muted);
+}
+
+.copilot-chat-model-selector-meta-text {
+	flex: 1;
+	min-width: 0;
+}
+
+.copilot-chat-model-selector-effort-group {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	position: relative;
+}
+
+
+.copilot-chat-model-selector-effort-button {
+	background-color: var(--background-secondary);
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	color: var(--text-normal);
+	padding: 4px 10px;
+	font-size: 0.8rem;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.copilot-chat-model-selector-effort-note {
+	font-size: 0.75rem;
+	color: var(--text-faint);
+}
+
+.copilot-chat-model-selector-effort-menu {
+	position: absolute;
+	top: calc(100% + 6px);
+	right: 0;
+	min-width: 160px;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+	padding: 6px;
+	z-index: 20;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.copilot-chat-model-selector-effort-option {
+	background: transparent;
+	border: none;
+	border-radius: 6px;
+	color: var(--text-normal);
+	padding: 8px 10px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.copilot-chat-model-selector-effort-option:hover {
+	background: var(--background-modifier-hover);
+}
+
+.copilot-chat-model-selector-effort-option-active {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
 }
 
 /***********************


### PR DESCRIPTION
- add a fuller Copilot model catalog with runtime discovery merge
- show model multipliers and a native-style grouped picker
- add reasoning effort controls for supported GPT-5 family models
- tighten model discovery so non-chat models are filtered out